### PR TITLE
MGRENTITLE-76: pass context values to error handler

### DIFF
--- a/src/main/java/org/folio/flow/impl/DefaultStageExecutor.java
+++ b/src/main/java/org/folio/flow/impl/DefaultStageExecutor.java
@@ -126,6 +126,7 @@ public final class DefaultStageExecutor<T extends StageContext> implements Stage
     var flowId = context.flowId();
     try {
       var contextWrapper = createContextWrapper(context);
+      context = contextWrapper;
       stage.execute(contextWrapper);
       log.debug("[{}] Stage '{}' executed with status: {}", flowId, stageId, SUCCESS);
       return getStageResult(contextWrapper, SUCCESS);

--- a/src/test/java/org/folio/flow/impl/DefaultStageExecutorTest.java
+++ b/src/test/java/org/folio/flow/impl/DefaultStageExecutorTest.java
@@ -45,7 +45,7 @@ class DefaultStageExecutorTest {
   }
 
   @Test
-  void execute_negative_contextPassed() throws Exception {
+  void execute_negative_contextPassed() {
     var contextAttributeVal = new AtomicReference<Object>();
     var stageExecutor = new DefaultStageExecutor<>(new Stage<StageContext>() {
       @Override
@@ -54,6 +54,7 @@ class DefaultStageExecutorTest {
         throw new RuntimeException("Testing");
       }
 
+      @Override
       public void onError(StageContext context, Exception exception) {
         contextAttributeVal.set(context.get("customkey"));
       }

--- a/src/test/java/org/folio/flow/impl/DefaultStageExecutorTest.java
+++ b/src/test/java/org/folio/flow/impl/DefaultStageExecutorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.folio.flow.api.AbstractStageContextWrapper;
 import org.folio.flow.api.Stage;
 import org.folio.flow.api.StageContext;
@@ -41,6 +42,27 @@ class DefaultStageExecutorTest {
   void tearDown() {
     verifyNoMoreInteractions(invalidSimpleStage, invalidSimpleStage2,
       falseCancellableStage, invalidListenableStage, invalidCancellableStage);
+  }
+
+  @Test
+  void execute_negative_contextPassed() throws Exception {
+    var contextAttributeVal = new AtomicReference<Object>();
+    var stageExecutor = new DefaultStageExecutor<>(new Stage<StageContext>() {
+      @Override
+      public void execute(StageContext context) {
+        context.put("customkey", "customval");
+        throw new RuntimeException("Testing");
+      }
+
+      public void onError(StageContext context, Exception exception) {
+        contextAttributeVal.set(context.get("customkey"));
+      }
+    });
+    var stageContext = stageContext();
+    var upstreamStageResult = stageExecutionResult("test", stageContext, SUCCESS);
+
+    stageExecutor.execute(upstreamStageResult, newSingleThreadExecutor());
+    assertThat(contextAttributeVal.get()).isEqualTo("customval");
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Ensure context values are passed to on-error handler in stage execution. This is needed to allow exchange of context attributes between execution and error handling parts of the stage.
